### PR TITLE
Update LocalWorkaround.ps1

### DIFF
--- a/LocalWorkaround.ps1
+++ b/LocalWorkaround.ps1
@@ -13,7 +13,7 @@ if($CVE20201350_WorkArround.TcpReceivePacketSize -ne 65280){
 write-host "Not Applied" -ForegroundColor Red
 
     try{
-    Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\DNS\Parameters" -Name "TcpReceivePacketSize" -Value 65280
+    Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\DNS\Parameters" -Name "TcpReceivePacketSize" -Type DWord -Value 65280
     write-host "Workaround Applied" -ForegroundColor Green
     try
     {Restart-Service -Name DNS


### PR DESCRIPTION
Create the correct type of registry key (DWORD), was previously creating a REG_SZ.